### PR TITLE
fix(Expandable): Center icon

### DIFF
--- a/src/components/Expandable/Expandable.tsx
+++ b/src/components/Expandable/Expandable.tsx
@@ -63,9 +63,15 @@ export const Expandable: React.FC<ExpandableProps> = ({
     >
       <Flex flexDir="row" justifyContent="space-between" alignItems="center">
         <Flex flexDir="row" alignItems="center">
-          <Box width="20" height="20" display={['none', null, null, 'unset']}>
+          <Flex
+            width="20"
+            height="20"
+            display={['none', null, null, 'flex']}
+            alignItems="center"
+            justifyContent="center"
+          >
             {icon}
-          </Box>
+          </Flex>
           <Box ml={['0', null, null, '8']}>
             <Flex flexDir="row" alignItems="center">
               <Text size="xsLowBold" color="gray.500" mr="2">


### PR DESCRIPTION
Previously, any icon would be aligned to the left top. Only square phosphor-icons with size 80 would appear centered.
This change centers all icons - or really any jsx element provided in the icon prop - vertically and horizontally in the parent div.

Before:
![before](https://user-images.githubusercontent.com/14820934/161427281-9200b954-8010-4154-b280-cc3f391969eb.png)

After:
![after](https://user-images.githubusercontent.com/14820934/161427284-d7f2350c-37f3-489a-a472-127278eddc59.png)

