### PR TITLE
Deprecate NavItem component

### DIFF
--- a/src/components/NavItem/NavItem.stories.tsx
+++ b/src/components/NavItem/NavItem.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { NavItem } from './NavItem';
 
 export default {
-  title: 'components/NavItem',
+  title: 'components/NavItem (deprecated)',
   component: NavItem,
 } as ComponentMeta<typeof NavItem>;
 


### PR DESCRIPTION
A navigation item should be a <a href=""></a> element. Not a button. Since in e.g. Next.js there are custom links that should be used it makes not much sense to have the NavItem in a component library.