### PR TITLE
feat(Select): Document and customize the Select component

### DIFF
--- a/src/constants/componentCustomizations.tsx
+++ b/src/constants/componentCustomizations.tsx
@@ -438,16 +438,28 @@ export const CustomizedSelect = {
   },
   sizes: {
     lg: {
-      fontSize: 'lg',
+      field: {
+        fontSize: 'lg',
+        borderRadius: inputSizes.lg.borderRadius,
+      },
     },
     md: {
-      fontSize: 'md',
+      field: {
+        fontSize: 'md',
+        borderRadius: inputSizes.md.borderRadius,
+      },
     },
     sm: {
-      fontSize: 'sm',
+      field: {
+        fontSize: 'sm',
+        borderRadius: inputSizes.sm.borderRadius,
+      },
     },
     xs: {
-      fontSize: 'xs',
+      field: {
+        fontSize: 'xs',
+        borderRadius: inputSizes.sm.borderRadius,
+      },
     },
   },
 };

--- a/src/stories/components/Select.stories.tsx
+++ b/src/stories/components/Select.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { Select } from '../..';
+
+export default {
+  title: 'Components/Select',
+  component: Select,
+  argTypes: {
+    variant: {
+      options: ['outline', 'filled', 'flushed', 'unstyled'],
+      control: { type: 'radio' },
+    },
+    size: {
+      options: ['xs', 'sm', 'md', 'lg'],
+      control: { type: 'radio' },
+    },
+    placeholder: { control: { type: 'text' } },
+    isDisabled: { control: { type: 'boolean' } },
+    isInvalid: { control: { type: 'boolean' } },
+    isFullWidth: { control: { type: 'boolean' } },
+    onChange: { action: 'Select changed' },
+    value: { control: { type: 'text' } },
+  },
+} as ComponentMeta<typeof Select>;
+
+const Template: ComponentStory<typeof Select> = (args) => (
+  <Select {...args}>
+    <option value="option_1">Option 1</option>
+    <option value="option_2">Option 2</option>
+  </Select>
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const WithPlaceholder = Template.bind({});
+WithPlaceholder.args = {
+  placeholder: 'Placeholder',
+};
+
+export const WithSelectedValue = Template.bind({});
+WithSelectedValue.args = {
+  value: 'option_2',
+};


### PR DESCRIPTION
The `Select` component of ChakraUI has already been usable in Boemly but was not documented and customized.