### PR TITLE
feat(Container): Use BoxProps for Container

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,9 +1,8 @@
-import type { StyleProps } from '@chakra-ui/react';
-import { Box } from '@chakra-ui/react';
 import React from 'react';
+import type { BoxProps } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 
-export interface ContainerProps extends StyleProps {
-  children: JSX.Element | JSX.Element[];
+export interface ContainerProps extends BoxProps {
   elevation?: 'none' | 'sm' | 'lg';
   padding?: 'md' | 'lg';
   fullWidth?: boolean;
@@ -37,7 +36,7 @@ export const Container: React.FC<ContainerProps> = ({
   elevation = 'sm',
   padding = 'md',
   fullWidth = true,
-  ...styleProps
+  ...boxProps
 }: ContainerProps) => (
   <Box
     borderWidth="thin"
@@ -49,7 +48,7 @@ export const Container: React.FC<ContainerProps> = ({
     paddingX={paddings[padding].paddingX}
     paddingY={paddings[padding].paddingY}
     display={fullWidth ? 'block' : 'inline-block'}
-    {...styleProps}
+    {...boxProps}
   >
     {children}
   </Box>


### PR DESCRIPTION
Use `BoxProps` instead of `StyleProps` for the Container component so that usage with `framer-motion` is easier.

This should not break anything since `BoxProps` extend `StyleProps`.

Example for usage: https://chakra-ui.com/getting-started/with-framer