### PR TITLE
fix(QuoteCard): Align avatar to bottom of container

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -48,8 +48,8 @@ export const Container: React.FC<ContainerProps> = ({
     backgroundColor="white"
     borderStyle="solid"
     boxShadow={elevations[elevation].boxShadow}
-    display={fullWidth ? 'block' : 'inline-block'}
-    {...styleProps}
+    display={fullWidth ? 'flex' : 'inline-flex'}
+    flexDirection="column"
   >
     {header && (
       <>
@@ -59,7 +59,12 @@ export const Container: React.FC<ContainerProps> = ({
         <Divider />
       </>
     )}
-    <Box paddingX={paddings[padding].paddingX} paddingY={paddings[padding].paddingY}>
+    <Box
+      height="full"
+      paddingX={paddings[padding].paddingX}
+      paddingY={paddings[padding].paddingY}
+      {...styleProps}
+    >
       {children}
     </Box>
   </Box>

--- a/src/components/QuoteCard/QuoteCard.tsx
+++ b/src/components/QuoteCard/QuoteCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from '@chakra-ui/react';
+import { Spacer, Text } from '@chakra-ui/react';
 import { AvatarWithName, AvatarWithNameProps } from '../AvatarWithName/AvatarWithName';
 import { Container } from '../Container';
 
@@ -9,10 +9,11 @@ export interface QuoteCardProps {
 }
 
 export const QuoteCard: React.FC<QuoteCardProps> = ({ text, avatar }: QuoteCardProps) => (
-  <Container borderRadius="2xl" padding="lg">
+  <Container borderRadius="2xl" padding="lg" display="flex" flexDir="column">
     <Text size="mdRegularNormalBold" color="black" mb="8">
       {text}
     </Text>
+    <Spacer />
     <AvatarWithName image={avatar.image} name={avatar.name} description={avatar.description} />
   </Container>
 );


### PR DESCRIPTION
fixes treely/app#585

Also makes it that if a header is present on the container, the children will only take up the rest of the space instead of being the same size as the parent.

And it fixes the alignment here: https://boemly.tree.ly/?path=/story/components-contactarea--default-props