### PR TITLE
fix(BoemlyTabs): Hide scrollbar when not needed.

### DIFF
--- a/src/components/BoemlyTabs/BoemlyTabs.tsx
+++ b/src/components/BoemlyTabs/BoemlyTabs.tsx
@@ -22,7 +22,7 @@ export const BoemlyTabs: FC<BoemlyTabsProps> = ({
 
   return (
     <Box>
-      <Flex width="full" gap="8" overflowX="scroll">
+      <Flex width="full" gap="8" overflowX="auto">
         {tabs.map((tab) => (
           <TabButton
             key={tab.key}


### PR DESCRIPTION
Previously, the scrollbar would show on windows even though there was no overflow:
![image](https://user-images.githubusercontent.com/14820934/189632469-598898fd-8a6b-49a2-bc68-1ea440e0e2da.png)
