### PR TITLE
fix(RichText): Add span styling definition

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -83,6 +83,11 @@ export const RichText: React.FC<RichTextProps> = ({
               {children}
             </Text>
           ),
+          span: ({ children }: ComponentProps) => (
+            <Text size="mdRegularNormal" color="gray.800" {...textProps}>
+              {children}
+            </Text>
+          ),
           code: ({ className, children }: CodeComponentProps) => {
             const language = className?.split('-')[1] || 'js';
             return (


### PR DESCRIPTION
Adds styling definition for `span` elements in the `RichText` component. 