### PR TITLE
feat(RichText): Render inline content in line

### DIFF
--- a/src/components/RichText/RichText.stories.tsx
+++ b/src/components/RichText/RichText.stories.tsx
@@ -112,3 +112,9 @@ CustomOrderedList.args = {
   `,
   listProps: { textColor: 'primary.500', textSize: 'xsMonoUppercase' },
 };
+
+export const InlineContent = Template.bind({});
+InlineContent.args = {
+  content:
+    'Inline *content* gets **rendered** in line, just like [markdown-to-jsx](https://github.com/probablyup/markdown-to-jsx) handles it.',
+};

--- a/src/components/RichText/RichText.test.tsx
+++ b/src/components/RichText/RichText.test.tsx
@@ -45,6 +45,30 @@ const setup = (props = {}) => {
 };
 
 describe('The RichText component', () => {
+  it('displays single line content as inline', () => {
+    setup({
+      content: '*Emphasised Text*',
+    });
+
+    expect(screen.getByTestId('rt-wrapper-span')).toBeInTheDocument();
+    expect(screen.queryByTestId('rt-wrapper-div')).not.toBeInTheDocument();
+
+    expect(screen.getByText('Emphasised Text').parentElement).toBe(
+      screen.getByTestId('rt-wrapper-span')
+    );
+  });
+
+  it('displays multi line content as a block', () => {
+    setup();
+
+    expect(screen.getByTestId('rt-wrapper-div')).toBeInTheDocument();
+    expect(screen.queryByTestId('rt-wrapper-span')).not.toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { level: 2 }).parentElement).toBe(
+      screen.getByTestId('rt-wrapper-div')
+    );
+  });
+
   it('displays the h1 from the Markdown as h2', () => {
     setup();
 

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -51,81 +51,98 @@ const getListItems = (children: ListChildren) => {
   return children ? children.map((child) => ({ id: child.key, text: child.props.children })) : [];
 };
 
+const SHOULD_RENDER_AS_BLOCK_R = /(\n|^[-*]\s|^#|^ {2,}|^-{2,}|^>\s)/;
+
 export const RichText: React.FC<RichTextProps> = ({
   content,
   headingProps = {},
   textProps = {},
   listProps = {},
 }: RichTextProps) => (
-  <Box {...textProps}>
-    <Markdown
-      options={{
-        overrides: {
-          h1: ({ children }: ComponentProps) => (
-            <Heading as="h2" size="2xl" mb="6" mt="8" {...headingProps}>
-              {children}
-            </Heading>
-          ),
-          h2: ({ children }: ComponentProps) => (
-            <Heading as="h3" size="xl" mb="4" mt="6" {...headingProps}>
-              {children}
-            </Heading>
-          ),
-          h3: ({ children }: ComponentProps) => (
-            <Heading as="h4" size="lg" mb="4" mt="6" {...headingProps}>
-              {children}
-            </Heading>
-          ),
-          h4: ({ children }: ComponentProps) => (
-            <Heading as="h5" size="md" mb="4" mt="6" {...headingProps}>
-              {children}
-            </Heading>
-          ),
-          p: ({ children }: ComponentProps) => (
-            <Text size="mdRegularNormal" color="gray.800" mb="12" {...textProps}>
-              {children}
-            </Text>
-          ),
-          span: ({ children }: ComponentProps) => (
-            <Text size="mdRegularNormal" color="gray.800" {...textProps}>
-              {children}
-            </Text>
-          ),
-          code: ({ className, children }: CodeComponentProps) => {
-            const language = className?.split('-')[1] || 'js';
-            return (
-              <Box backgroundColor="primary.50" borderRadius="lg" padding="2" mb="12">
-                <SyntaxHighlighter
-                  language={language}
-                  style={docco}
-                  customStyle={{ background: 'unset' }}
-                >
-                  {children}
-                </SyntaxHighlighter>
-              </Box>
-            );
-          },
-          blockquote: ({ children }: ComponentProps) => (
-            <Box mb="12" pl="4" borderLeft="solid" borderLeftWidth="medium">
-              {children}
+  <Markdown
+    options={{
+      wrapper: ({ children }: ComponentProps) =>
+        SHOULD_RENDER_AS_BLOCK_R.test(content) ? (
+          <Box {...textProps} as="div" data-testid="rt-wrapper-div">
+            {children}
+          </Box>
+        ) : (
+          <Text
+            size="mdRegularNormal"
+            color="gray.800"
+            {...textProps}
+            as="span"
+            data-testid="rt-wrapper-span"
+          >
+            {children}
+          </Text>
+        ),
+      forceWrapper: true,
+      overrides: {
+        h1: ({ children }: ComponentProps) => (
+          <Heading as="h2" size="2xl" mb="6" mt="8" {...headingProps}>
+            {children}
+          </Heading>
+        ),
+        h2: ({ children }: ComponentProps) => (
+          <Heading as="h3" size="xl" mb="4" mt="6" {...headingProps}>
+            {children}
+          </Heading>
+        ),
+        h3: ({ children }: ComponentProps) => (
+          <Heading as="h4" size="lg" mb="4" mt="6" {...headingProps}>
+            {children}
+          </Heading>
+        ),
+        h4: ({ children }: ComponentProps) => (
+          <Heading as="h5" size="md" mb="4" mt="6" {...headingProps}>
+            {children}
+          </Heading>
+        ),
+        p: ({ children }: ComponentProps) => (
+          <Text size="mdRegularNormal" color="gray.800" mb="12" {...textProps}>
+            {children}
+          </Text>
+        ),
+        span: ({ children }: ComponentProps) => (
+          <Text size="mdRegularNormal" color="gray.800" {...textProps} as="span">
+            {children}
+          </Text>
+        ),
+        code: ({ className, children }: CodeComponentProps) => {
+          const language = className?.split('-')[1] || 'js';
+          return (
+            <Box backgroundColor="primary.50" borderRadius="lg" padding="2" mb="12">
+              <SyntaxHighlighter
+                language={language}
+                style={docco}
+                customStyle={{ background: 'unset' }}
+              >
+                {children}
+              </SyntaxHighlighter>
             </Box>
-          ),
-          ul: ({ children }: ListComponentProps) => (
-            <BoemlyList listItems={getListItems(children)} mb="12" {...listProps} />
-          ),
-          ol: ({ children }: ListComponentProps) => (
-            <BoemlyList listItems={getListItems(children)} ordered mb="12" {...listProps} />
-          ),
-          a: ({ children, href }: LinkComponentProps) => (
-            <Link size="md" href={href}>
-              {children}
-            </Link>
-          ),
-          img: ({ src, alt }: ImageComponentProps) => <ImageContainer src={src} alt={alt} />,
+          );
         },
-      }}
-    >
-      {content}
-    </Markdown>
-  </Box>
+        blockquote: ({ children }: ComponentProps) => (
+          <Box mb="12" pl="4" borderLeft="solid" borderLeftWidth="medium">
+            {children}
+          </Box>
+        ),
+        ul: ({ children }: ListComponentProps) => (
+          <BoemlyList listItems={getListItems(children)} mb="12" {...listProps} />
+        ),
+        ol: ({ children }: ListComponentProps) => (
+          <BoemlyList listItems={getListItems(children)} ordered mb="12" {...listProps} />
+        ),
+        a: ({ children, href }: LinkComponentProps) => (
+          <Link size="md" href={href}>
+            {children}
+          </Link>
+        ),
+        img: ({ src, alt }: ImageComponentProps) => <ImageContainer src={src} alt={alt} />,
+      },
+    }}
+  >
+    {content}
+  </Markdown>
 );


### PR DESCRIPTION
Uses the same logic as probablyup/markdown-to-jsx to decide whether to render the content as inline or block.
Wraps inline content in a chakra-ui `<Text>` tag and applies the `textProps` to it. Behaviour for block content remains unchanged.