### PR TITLE
fix(DatePicker): Open on click on InputAddon

### DIFF
--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -80,4 +80,16 @@ describe('The DatePicker component', () => {
     expect(onChangeSpy).toHaveBeenCalledWith(new Date('2022-02-12'));
     expect(onSelectSpy).toHaveBeenCalledWith(new Date('2022-02-12'));
   });
+
+  it('also allows to change the date when clicking on the icon', () => {
+    setup();
+
+    fireEvent.click(screen.getByTestId('calendar-icon'));
+
+    fireEvent.click(screen.getByTestId('calendar-icon'));
+    fireEvent.click(screen.getByText('12'));
+
+    expect(onChangeSpy).toHaveBeenCalledWith(new Date('2022-01-12'));
+    expect(onSelectSpy).toHaveBeenCalledWith(new Date('2022-01-12'));
+  });
 });

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -5,12 +5,13 @@ import {
   IconButton,
   Input,
   InputGroup,
+  InputProps,
   InputRightAddon,
   Select,
   Spacer,
 } from '@chakra-ui/react';
 import { CalendarBlank, CaretLeft, CaretRight } from 'phosphor-react';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import de from 'date-fns/locale/de';
 import en from 'date-fns/locale/en-US';
@@ -38,7 +39,9 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   placeholder,
   size = 'md',
 }: DatePickerProps) => {
-  const CustomInput = forwardRef(({ value, onClick }, ref) => (
+  const datePickerRef = useRef<ReactDatePicker>(null);
+
+  const CustomInput = forwardRef<InputProps, typeof Input>(({ value, onClick }, ref) => (
     <InputGroup size={size}>
       <Input
         data-testid="datepicker-input"
@@ -51,8 +54,14 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         placeholder={placeholder}
         readOnly
       />
-      <InputRightAddon>
-        <CalendarBlank size={16} />
+      <InputRightAddon
+        _hover={{ cursor: 'pointer' }}
+        onClick={(ev) => {
+          onClick && onClick(ev as any);
+          datePickerRef.current?.setFocus();
+        }}
+      >
+        <CalendarBlank size={16} data-testid="calendar-icon" />
       </InputRightAddon>
     </InputGroup>
   ));
@@ -70,6 +79,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   return (
     <Box css={datePickerStyle}>
       <ReactDatePicker
+        ref={datePickerRef}
         renderCustomHeader={({
           date,
           changeYear,


### PR DESCRIPTION
Opens the datepicker and focusses on the input element when the user clicks on the calender icon.