### PR TITLE
fix(DefaultSectionHeader): Font color for rich text sub title

### DIFF
--- a/src/components/DefaultSectionHeader/DefaultSectionHeader.tsx
+++ b/src/components/DefaultSectionHeader/DefaultSectionHeader.tsx
@@ -52,6 +52,9 @@ export const DefaultSectionHeader: React.FC<DefaultSectionHeaderProps> = ({
             color: textProps.color || 'gray.500',
             size: isHero ? 'lgRegularNormal' : 'mdRegularNormal',
           }}
+          listProps={{
+            textColor: (textProps.color as string) || 'gray.500',
+          }}
         />
       </Box>
     )}


### PR DESCRIPTION
Fixes https://github.com/treely/app/issues/959