### PR TITLE
fix(Header): Fix the Header for mobile screen

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { Header } from '.';
+
+export default {
+  title: 'components/Header',
+  component: Header,
+  args: {
+    left: (
+      <div
+        style={{
+          backgroundColor: 'var(--boemly-colors-green-500)',
+          width: 'var(--boemly-sizes-full)',
+        }}
+      >
+        Left
+      </div>
+    ),
+    center: (
+      <div
+        style={{
+          backgroundColor: 'var(--boemly-colors-red-500)',
+          width: 'var(--boemly-sizes-full)',
+        }}
+      >
+        Center
+      </div>
+    ),
+    right: (
+      <div
+        style={{
+          backgroundColor: 'var(--boemly-colors-orange-500)',
+          width: 'var(--boemly-sizes-full)',
+        }}
+      >
+        Right
+      </div>
+    ),
+  },
+} as Meta<typeof Header>;
+
+const Template: StoryFn<typeof Header> = (args) => <Header {...args} />;
+
+export const DefaultProps = Template.bind({});
+DefaultProps.args = {};

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -3,6 +3,8 @@ import { Header } from '.';
 import { render, screen } from '../../test/testUtils';
 import { HeaderProps } from './Header';
 
+const mockedResult = jest.fn().mockReturnValue({ isMobile: false });
+
 const defaultProps: HeaderProps = {
   left: 'left',
   center: 'center',
@@ -15,13 +17,34 @@ const setup = (props = {}) => {
 };
 
 describe('The Header component', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      })),
+    });
+  });
+  afterEach(() => {
+    mockedResult.mockClear();
+  });
+
   it('renders the left prop', () => {
     setup();
 
     expect(screen.getByText('left')).toBeInTheDocument();
   });
 
-  it('renders the center prop', () => {
+  it('renders the center prop if the screen is not mobile', () => {
+    setup();
+
+    expect(screen.getByText('center')).toBeInTheDocument();
+  });
+
+  it('does not render the center prop if the screen is mobile', () => {
+    mockedResult.mockReturnValue({ isMobile: true });
     setup();
 
     expect(screen.getByText('center')).toBeInTheDocument();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,12 +15,14 @@ export const Header: React.FC<HeaderProps> = ({ left, center, right }: HeaderPro
     alignItems="center"
     justifyContent="space-between"
   >
-    <Flex width="24%" flexDir="row" justifyContent="flex-start">
+    <Flex width={['76%', null, null, '24%']} flexDir="row" justifyContent="flex-start">
       {left}
     </Flex>
-    <Flex width="50%" flexDir="row" justifyContent="center">
+
+    <Flex display={['none', null, null, 'unset']} width="50%" flexDir="row" justifyContent="center">
       {center}
     </Flex>
+
     <Flex width="24%" flexDir="row" justifyContent="flex-end">
       {right}
     </Flex>


### PR DESCRIPTION
## Impediments: 
https://trello.com/c/ykivdeGd/467-silvaconsult-logo-in-mobile-header-is-cut-off-and-too-small
https://trello.com/c/KawGcf7b/336-improvements-carbon-buyer-confirmation

### Preview: 
https://boemly-4dyw19o0q-treely.vercel.app/?path=/story/components-header--default-props

### Preview with Logo: 
https://boemly-dx08fueam-treely.vercel.app/?path=/story/components-header--default-props

- [x] Fix the size of the left side of the `Header` for the mobile screen