### PR TITLE
fix(datepicker): date in onSelect prop is always defined

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -30,7 +30,7 @@ export interface DatePickerProps extends Omit<InputGroupProps, 'onChange' | 'onS
 
   // These collide with the props inherited from `InputGroupProps`
   onChange?: (date: Date | undefined) => void;
-  onSelect?: (date: Date | undefined) => void;
+  onSelect?: (date: Date) => void;
 }
 
 export const DatePicker: React.FC<DatePickerProps> = ({


### PR DESCRIPTION
I made a mistake in setting this to `Date | undefined` in #204 
`onSelect` gets fired when a date in the component is selected. So it is always defined.