### PR TITLE
feat(slider): enable change of slider value though a prop

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -42,6 +42,7 @@ WithCustomMinAndMax.args = {
 export const WithLowerAndUpperBound = Template.bind({});
 WithLowerAndUpperBound.args = {
   variant: 'boundary',
+  value: 45,
   min: 10,
   max: 90,
   lowerBoundText: 'Lower bound',

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -122,5 +122,15 @@ describe('The Slider component', () => {
 
       expect(screen.getByRole('tooltip')).toBeInTheDocument();
     });
+
+    it('updates the slider value when the external value prop changes', () => {
+      const { rerender } = render(<Slider {...defaultProps} value={30} onChange={onChangeSpy} />);
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '30');
+
+      rerender(<Slider {...defaultProps} value={70} onChange={onChangeSpy} />);
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '70');
+    });
   });
 });

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 import { StyleProps, useMediaQuery } from '@chakra-ui/react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Slider,
   SliderTrack,
@@ -15,6 +15,7 @@ import CustomSliderThumb from './CustomSliderThumb';
 export interface SliderProps extends StyleProps {
   variant?: 'default' | 'boundary';
   defaultValue?: number;
+  value?: number;
   ariaLabel: string;
   min?: number;
   max?: number;
@@ -27,6 +28,7 @@ export interface SliderProps extends StyleProps {
 export const BoemlySlider: React.FC<SliderProps> = ({
   variant = 'default',
   defaultValue,
+  value,
   ariaLabel,
   min = 0,
   max = 100,
@@ -39,16 +41,25 @@ export const BoemlySlider: React.FC<SliderProps> = ({
   const [isMobile] = useMediaQuery(BREAKPOINT_MD_QUERY);
 
   const initialValue = useMemo(
-    () => defaultValue ?? min + (max - min) / 2,
-    [defaultValue, min, max]
+    () => value ?? defaultValue ?? min + (max - min) / 2,
+    [defaultValue, min, max, value]
   );
+
   const [sliderValue, setSliderValue] = useState(initialValue);
   const [inputValue, setInputValue] = useState(initialValue.toString());
 
-  const sliderOnChange = (value: number) => {
-    setSliderValue(value);
-    setInputValue(value.toString());
-    onChange(value);
+  // Update internal sliderValue when the external value prop changes
+  useEffect(() => {
+    if (value !== undefined) {
+      setSliderValue(value);
+      setInputValue(value.toString());
+    }
+  }, [value]);
+
+  const sliderOnChange = (newValue: number) => {
+    setSliderValue(newValue);
+    setInputValue(newValue.toString());
+    onChange(newValue);
   };
 
   const inputOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
I just came across the problem that when I use the new Slider and want to change the value from "outside" (in this case the input field) I don't have the possibility to change the slider value because we don't have a prop to set the value. This solves this problem.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/4a168da4-59c9-4dbc-a896-32987916d5af">
