### PR TITLE
fix: fix the text-card button

### DIFF
--- a/src/components/TextCardWithIcon/TextCardWithIcon.tsx
+++ b/src/components/TextCardWithIcon/TextCardWithIcon.tsx
@@ -76,20 +76,28 @@ export const TextCardWithIcon: React.FC<TextCardWithIconProps> = ({
         </Box>
       )}
       {!image && Icon}
-      <div>
-        <Flex alignItems="center" gap="2" mb={image ? '2' : '0'} mt={image ? '6' : '0'}>
+      <Flex flexDirection="column">
+        <Flex
+          alignItems="center"
+          justifyContent="flex-start"
+          gap="2"
+          mb={image ? '2' : '0'}
+          mt={image ? '6' : '0'}
+        >
           {image && Icon}
           <Heading as="h6" size="xs" mb="2">
             {title}
           </Heading>
         </Flex>
-        <Text size="smRegularNormal">{text}</Text>
-        {button && (
-          <Button width="full" mt="6" size="lg" onClick={button.onClick}>
-            {button.text}
-          </Button>
-        )}
-      </div>
+        <Text size="smRegularNormal" marginBottom="6">
+          {text}
+        </Text>
+      </Flex>
+      {button && (
+        <Button mt="auto" size="lg" onClick={button.onClick}>
+          {button.text}
+        </Button>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
In `TextCarousel` component in strapi-slices the button of `TextCardWithIcon` component moves depending of amount of the text; additionally in combination with other cards the button gains some space around, what is not preferable behaviour. This PR fixis it, unfortunately the fix is not possible to see it in storybook