### PR TITLE
fix: select text color

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -328,7 +328,7 @@ export const BoemlySelect: React.FC<BoemlySelectProps> = ({
                           <Text
                             fontSize={CustomizedSelect.sizes[size].fontSize}
                             fontWeight={isSelected ? 'bold' : 'normal'}
-                            color={isSelected ? 'black' : color}
+                            color="black"
                           >
                             {isMatch ? (
                               <>


### PR DESCRIPTION
Fixes: https://trello.com/c/gUy7r9z7/636-set-boemly-select-text-color-to-always-be-black