### PR TITLE
feat: add dropdwonWidth prop to select

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -44,6 +44,8 @@ export interface BoemlySelectProps extends Omit<SelectProps, 'onChange' | 'value
   selectAllText?: string;
   value?: string[];
   size?: 'xs' | 'sm' | 'md' | 'lg';
+  // dropdownWidth addresses the issue in Firefox browser by preventing  jerky scrolling and items disappearing when there are too many items.
+  dropdownWidth?: '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   variant?: 'filled' | 'unstyled' | 'flushed' | 'outline';
   onChange?: (value: string[]) => void;
   onClose?: () => void;
@@ -64,6 +66,7 @@ export const BoemlySelect: React.FC<BoemlySelectProps> = ({
   preventDeselection = false,
   selectAllText = 'Select All',
   size = 'md',
+  dropdownWidth,
   variant = 'outline',
   borderColor = CustomizedSelect.variants[variant].borderColor,
   backgroundColor = CustomizedSelect.variants[variant].backgroundColor,
@@ -259,6 +262,7 @@ export const BoemlySelect: React.FC<BoemlySelectProps> = ({
               maxHeight={dynamicMaxHeight}
               overflowY="auto"
               zIndex="popover"
+              width={dropdownWidth}
             >
               {isSearchable && (
                 <InputGroup mb="4">


### PR DESCRIPTION
Impediment: https://trello.com/c/jsan91I0/648-project-design-studio-feasibility-study-editor-bug-reported-from-tnl-partner-project-developer

This PR was tested with npm run build and npm pack in boemly and then the .tgz file created in boemly was installed to app repository. Added in app in NormalStockForm component the prop `dropdownWidth:"3xs"` on line 533. Then on Firefox browser opened http://localhost:3000/app/projects/ in any project where there is no FS study yet; opened 'Create FS Study' and filled the fields on the first step. On the second step the issue is in "Yield Table" Select dropdown.
Also the issue appears in fpm in the page https://fpm.tree.ly/app/transactions on "From Account" and "To Account" dropdowns.